### PR TITLE
Support for loading style from a github repo and branch

### DIFF
--- a/src/comparator.html
+++ b/src/comparator.html
@@ -182,7 +182,7 @@
         };
       }
 
-      let isGist = false;
+      let skiLocalStorage = false;
       var atlas = {
         world: {
           id: "world",
@@ -249,7 +249,7 @@
       function applyUserStyleFromStorage() {
         // Try to read the local storage
         if (
-          !isGist &&
+          !skiLocalStorage &&
           localStorage &&
           localStorage.getItem("maputnik:latest_style")
         ) {
@@ -299,7 +299,7 @@
               if (!"style.json" in data.files) {
                 throw "style.json file not found in gist";
               } else {
-                isGist = true;
+                skiLocalStorage = true;
 
                 const styleJson = JSON.parse(data.files["style.json"].content);
 
@@ -327,7 +327,64 @@
               console.error(error);
               applyUserStyleFromStorage();
             });
-        } else {
+        } // Github commit
+        if (params.has("github")) {
+          const github = params.get("github");
+          const ref = params.get("ref") !== 0 ? params.get("ref") : "";
+          const url = `https://api.github.com/repos/${github}/contents/style.json${
+            ref ? "?ref=" + ref : ""
+          }`;
+
+          fetch(url, {
+            headers: {
+              Accept: "application/vnd.github.v3.raw",
+            },
+          })
+            .then((response) => {
+              if (response.status !== 200) {
+                throw `${response.statusText} (${response.status})`;
+              } else {
+                return response.json();
+              }
+            })
+            .then((styleJson) => {
+              skiLocalStorage = true;
+
+              for (const map of userMaps) {
+                map.setStyle(styleJson);
+              }
+
+              // Change right panel title
+              const title = document.getElementById("h2-your-style");
+              const url = `https://github.com/${github}/blob/${
+                ref ? ref : ""
+              }/style.json`;
+              const ellRef = ref.length > 10 ? ref.slice(0,7) + '...' : ref;
+
+              title.innerHTML = `<a class="link hover-dark-red" href="${url}">${github} ${
+                ref ? "(" + ellRef + ")" : ""
+              }</a>`;
+
+              // Add gist parameter to style links
+              const links = document.querySelectorAll(".style-link");
+              for (const link of links) {
+                const href = link.getAttribute("href");
+
+                const url = `${href}&github=${github}${
+                  ref ? "&ref=" + ref : ""
+                }`;
+
+                link.setAttribute("href", url);
+              }
+            })
+            .catch((error) => {
+              showErrorModal(error);
+              console.error(error);
+              applyUserStyleFromStorage();
+            });
+        }
+        // Without known params, apply from editor
+        else {
           applyUserStyleFromStorage();
         }
       }


### PR DESCRIPTION
While working on styles I can see the value of being able to pull into the comparator tool a style coming from a work uploaded into Github.

This change adds processing of `github` and `ref` parameters to load a style from a Github repository and branch. It works as follows:

* `github=org/repo`: gets your organization and repository, example `jsanz/osm-bright-gl-style`
* `ref=branch|commit`: accepts the name of an existing branch or a commit hash. If this parameter is not passed, the default branch content will be retrieved.

Example screenshot of the tool loading the style from the branch that is being discussed on this [Pull Request](https://github.com/elastic/osm-bright-gl-style/pull/4)

![image](https://user-images.githubusercontent.com/188264/88933347-90c91c00-d27f-11ea-8d61-da6c0f471954.png)
