### PR TITLE
Load style from Github

### DIFF
--- a/src/comparator.html
+++ b/src/comparator.html
@@ -399,6 +399,7 @@
               for (const map of userMaps) {
                 map.setStyle(styleJson);
               }
+              userMaps[0].setCenter(userMaps[0].getCenter());
 
               // Change right panel title
               const title = document.getElementById("h2-your-style");

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -381,6 +381,7 @@
             headers: {
               Accept: "application/vnd.github.v3.raw",
             },
+            credentials: 'omit',
           })
             .then((response) => {
               if (response.status !== 200) {

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -374,9 +374,8 @@
         if (params.has("github")) {
           const github = params.get("github");
           const ref = params.get("ref") !== 0 ? params.get("ref") : "";
-          const url = `https://api.github.com/repos/${github}/contents/style.json${
-            ref ? "?ref=" + ref : ""
-          }`;
+          const url = new URL(`/repos/${github}/contents/style.json`, 'https://api.github.com');
+          if (ref) url.search = `?ref=${ref}`;
 
           fetch(url, {
             headers: {

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -182,7 +182,7 @@
         };
       }
 
-      let skiLocalStorage = false;
+      let skipLocalStorage = false;
       var atlas = {
         world: {
           id: "world",
@@ -249,7 +249,7 @@
       function applyUserStyleFromStorage() {
         // Try to read the local storage
         if (
-          !skiLocalStorage &&
+          !skipLocalStorage &&
           localStorage &&
           localStorage.getItem("maputnik:latest_style")
         ) {
@@ -299,7 +299,7 @@
               if (!"style.json" in data.files) {
                 throw "style.json file not found in gist";
               } else {
-                skiLocalStorage = true;
+                skipLocalStorage = true;
 
                 const styleJson = JSON.parse(data.files["style.json"].content);
 
@@ -348,7 +348,7 @@
               }
             })
             .then((styleJson) => {
-              skiLocalStorage = true;
+              skipLocalStorage = true;
 
               for (const map of userMaps) {
                 map.setStyle(styleJson);

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -314,7 +314,7 @@
 
                 title.innerHTML = `<a class="link hover-dark-red" href="${gistUrl}">${data.description}</a>`;
 
-                // Add gist parameter to style links
+                // Add github parameter to style links
                 const links = document.querySelectorAll(".style-link");
                 for (const link of links) {
                   const href = link.getAttribute("href");

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -182,7 +182,7 @@
         };
       }
 
-      let isGist = false;
+      let skiLocalStorage = false;
       var atlas = {
         world: {
           id: "world",
@@ -249,7 +249,7 @@
       function applyUserStyleFromStorage() {
         // Try to read the local storage
         if (
-          !isGist &&
+          !skiLocalStorage &&
           localStorage &&
           localStorage.getItem("maputnik:latest_style")
         ) {
@@ -299,7 +299,7 @@
               if (!"style.json" in data.files) {
                 throw "style.json file not found in gist";
               } else {
-                isGist = true;
+                skiLocalStorage = true;
 
                 const styleJson = JSON.parse(data.files["style.json"].content);
 
@@ -327,7 +327,64 @@
               console.error(error);
               applyUserStyleFromStorage();
             });
-        } else {
+        } // Github commit
+        if (params.has("github")) {
+          const github = params.get("github");
+          const ref = params.get("ref") !== 0 ? params.get("ref") : "";
+          const url = `https://api.github.com/repos/${github}/contents/style.json${
+            ref ? "?ref=" + ref : ""
+          }`;
+
+          fetch(url, {
+            headers: {
+              Accept: "application/vnd.github.v3.raw",
+            },
+          })
+            .then((response) => {
+              if (response.status !== 200) {
+                throw `${response.statusText} (${response.status})`;
+              } else {
+                return response.json();
+              }
+            })
+            .then((styleJson) => {
+              skiLocalStorage = true;
+
+              for (const map of userMaps) {
+                map.setStyle(styleJson);
+              }
+
+              // Change right panel title
+              const title = document.getElementById("h2-your-style");
+              const url = `https://github.com/${github}/blob/${
+                ref ? ref : ""
+              }/style.json`;
+              const ellRef = ref.length > 10 ? ref.slice(0,7) + '...' : ref;
+
+              title.innerHTML = `<a class="link hover-dark-red" href="${url}">${github} ${
+                ref ? "(" + ellRef + ")" : ""
+              }</a>`;
+
+              // Add gist parameter to style links
+              const links = document.querySelectorAll(".style-link");
+              for (const link of links) {
+                const href = link.getAttribute("href");
+
+                const url = `${href}&github=${github}${
+                  ref ? "&ref=" + ref : ""
+                }`;
+
+                link.setAttribute("href", url);
+              }
+            })
+            .catch((error) => {
+              showErrorModal(error);
+              console.error(error);
+              applyUserStyleFromStorage();
+            });
+        }
+        // Without known params, apply from editor
+        else {
           applyUserStyleFromStorage();
         }
       }

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <title>Elastic Maps Service Style Compare</title>
   <style>
-    h2 {
-      z-index: 9999;
-    }
     .mapboxgl-ctrl-attrib {
       display: none;
+    }
+    #location {
+      left: 50%;
     }
   </style>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -36,6 +36,9 @@
         </div>
       </article>
     </dialog>
+    <div id="location" class="z-9999 absolute t0 w5 nl6 mr-auto">
+      <p class="tc pa1 code f6 ba b--yellow bg-washed-yellow o-60 center"></p>
+    </div>
     <dialog class="welcome w-50 measure dn sans-serif">
       <form method="dialog">
         <input type="submit" value="x" class="fr ba br1" />
@@ -64,7 +67,7 @@
     </dialog>
     <article class="">
       <div class="bg-near-white fl w-50 vh-100 br">
-        <h2 class="absolute top-0 left-1 pa1 sans-serif f4 bg-white o-60">
+        <h2 class="z-9999 absolute top-0 left-1 pa1 sans-serif f5 bg-white o-60">
           Production Styles:
           <a class="style-link link hover-dark-red" href="?style=osm-bright"
             >bright</a
@@ -89,7 +92,7 @@
       <div class="fl w-50 bg-light-gray vh-100">
         <h2
           id="h2-your-style"
-          class="absolute top-0 right-1 pa1 sans-serif f4 bg-white o-60"
+          class="z-9999 absolute top-0 right-1 pa1 sans-serif f5 bg-white o-60"
         ></h2>
         <div id="world-user" class="mainMap bb pa2 vh-50"></div>
         <div class="flex flex-wrap">
@@ -103,12 +106,42 @@
     <script src="https://unpkg.com/dialog-polyfill@0.5.1/dist/dialog-polyfill.js"></script>
     <script src="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.js"></script>
     <script>
+      function format(center, zoom) {
+        const z = zoom.toFixed(2);
+        const lat = center.lat.toFixed(2);
+        const lng = center.lng.toFixed(2);
+
+        const locationP = document.querySelector("#location p");
+
+        locationP.innerText = `${z}/${lat}/${lng}`;
+
+        // replace
+        const classesP = locationP.classList;
+        for ( const c of locationBackgroundClasses){
+          if (classesP.contains(c)){
+            const newClass = locationBackgroundClasses[parseInt(z) % locationBackgroundClasses.length];
+
+            // Color
+            classesP.replace(c, newClass);
+
+            // Border color
+            const prevBorder = c.replace('bg-washed-','b--');
+            const newBorder = newClass.replace('bg-washed-','b--');
+            classesP.replace(prevBorder, newBorder);
+
+            break;
+          }
+        }
+      }
+
       // https://github.com/mapbox/mapbox-gl-sync-move
       function moveToMapPosition(master, clones) {
         var center = master.getCenter();
         var zoom = master.getZoom();
         var bearing = master.getBearing();
         var pitch = master.getPitch();
+
+        format(center, zoom);
 
         clones.forEach(function (clone) {
           clone.jumpTo({
@@ -188,6 +221,7 @@
           id: "world",
           center: [0, 0],
           zoom: 1,
+          hash: true,
         },
         london: {
           id: "london",
@@ -212,6 +246,13 @@
       };
 
       var userMaps = [];
+      const locationBackgroundClasses = [
+        'bg-washed-red',
+        'bg-washed-green',
+        'bg-washed-blue',
+        'bg-washed-yellow'
+      ];
+
       let style = "osm-bright";
 
       if ("URLSearchParams" in window) {
@@ -263,6 +304,7 @@
           for (const map of userMaps) {
             map.setStyle(styleJson);
           }
+          userMaps[0].setCenter(userMaps[0].getCenter());
         }
       }
 
@@ -306,6 +348,7 @@
                 for (const map of userMaps) {
                   map.setStyle(styleJson);
                 }
+                userMaps[0].setCenter(userMaps[0].getCenter());
 
                 // Change right panel title
                 const title = document.getElementById("h2-your-style");

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -338,6 +338,7 @@
             headers: {
               Accept: "application/vnd.github.v3.raw",
             },
+            credentials: 'omit',
           })
             .then((response) => {
               if (response.status !== 200) {

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -215,7 +215,7 @@
         };
       }
 
-      let skiLocalStorage = false;
+      let skipLocalStorage = false;
       var atlas = {
         world: {
           id: "world",
@@ -290,7 +290,7 @@
       function applyUserStyleFromStorage() {
         // Try to read the local storage
         if (
-          !skiLocalStorage &&
+          !skipLocalStorage &&
           localStorage &&
           localStorage.getItem("maputnik:latest_style")
         ) {
@@ -341,7 +341,7 @@
               if (!"style.json" in data.files) {
                 throw "style.json file not found in gist";
               } else {
-                skiLocalStorage = true;
+                skipLocalStorage = true;
 
                 const styleJson = JSON.parse(data.files["style.json"].content);
 
@@ -391,7 +391,7 @@
               }
             })
             .then((styleJson) => {
-              skiLocalStorage = true;
+              skipLocalStorage = true;
 
               for (const map of userMaps) {
                 map.setStyle(styleJson);

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -357,7 +357,7 @@
 
                 title.innerHTML = `<a class="link hover-dark-red" href="${gistUrl}">${data.description}</a>`;
 
-                // Add gist parameter to style links
+                // Add github parameter to style links
                 const links = document.querySelectorAll(".style-link");
                 for (const link of links) {
                   const href = link.getAttribute("href");

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -215,7 +215,7 @@
         };
       }
 
-      let isGist = false;
+      let skiLocalStorage = false;
       var atlas = {
         world: {
           id: "world",
@@ -290,7 +290,7 @@
       function applyUserStyleFromStorage() {
         // Try to read the local storage
         if (
-          !isGist &&
+          !skiLocalStorage &&
           localStorage &&
           localStorage.getItem("maputnik:latest_style")
         ) {
@@ -341,7 +341,7 @@
               if (!"style.json" in data.files) {
                 throw "style.json file not found in gist";
               } else {
-                isGist = true;
+                skiLocalStorage = true;
 
                 const styleJson = JSON.parse(data.files["style.json"].content);
 
@@ -370,7 +370,64 @@
               console.error(error);
               applyUserStyleFromStorage();
             });
-        } else {
+        } // Github commit
+        if (params.has("github")) {
+          const github = params.get("github");
+          const ref = params.get("ref") !== 0 ? params.get("ref") : "";
+          const url = `https://api.github.com/repos/${github}/contents/style.json${
+            ref ? "?ref=" + ref : ""
+          }`;
+
+          fetch(url, {
+            headers: {
+              Accept: "application/vnd.github.v3.raw",
+            },
+          })
+            .then((response) => {
+              if (response.status !== 200) {
+                throw `${response.statusText} (${response.status})`;
+              } else {
+                return response.json();
+              }
+            })
+            .then((styleJson) => {
+              skiLocalStorage = true;
+
+              for (const map of userMaps) {
+                map.setStyle(styleJson);
+              }
+
+              // Change right panel title
+              const title = document.getElementById("h2-your-style");
+              const url = `https://github.com/${github}/blob/${
+                ref ? ref : ""
+              }/style.json`;
+              const ellRef = ref.length > 10 ? ref.slice(0,7) + '...' : ref;
+
+              title.innerHTML = `<a class="link hover-dark-red" href="${url}">${github} ${
+                ref ? "(" + ellRef + ")" : ""
+              }</a>`;
+
+              // Add gist parameter to style links
+              const links = document.querySelectorAll(".style-link");
+              for (const link of links) {
+                const href = link.getAttribute("href");
+
+                const url = `${href}&github=${github}${
+                  ref ? "&ref=" + ref : ""
+                }`;
+
+                link.setAttribute("href", url);
+              }
+            })
+            .catch((error) => {
+              showErrorModal(error);
+              console.error(error);
+              applyUserStyleFromStorage();
+            });
+        }
+        // Without known params, apply from editor
+        else {
           applyUserStyleFromStorage();
         }
       }

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -331,9 +331,8 @@
         if (params.has("github")) {
           const github = params.get("github");
           const ref = params.get("ref") !== 0 ? params.get("ref") : "";
-          const url = `https://api.github.com/repos/${github}/contents/style.json${
-            ref ? "?ref=" + ref : ""
-          }`;
+          const url = new URL(`/repos/${github}/contents/style.json`, 'https://api.github.com');
+          if (ref) url.search = `?ref=${ref}`;
 
           fetch(url, {
             headers: {

--- a/src/comparator.html
+++ b/src/comparator.html
@@ -374,14 +374,17 @@
         if (params.has("github")) {
           const github = params.get("github");
           const ref = params.get("ref") !== 0 ? params.get("ref") : "";
-          const url = new URL(`/repos/${github}/contents/style.json`, 'https://api.github.com');
+          const url = new URL(
+            `/repos/${github}/contents/style.json`,
+            "https://api.github.com"
+          );
           if (ref) url.search = `?ref=${ref}`;
 
           fetch(url, {
             headers: {
               Accept: "application/vnd.github.v3.raw",
             },
-            credentials: 'omit',
+            credentials: "omit",
           })
             .then((response) => {
               if (response.status !== 200) {
@@ -402,13 +405,22 @@
               const url = `https://github.com/${github}/blob/${
                 ref ? ref : ""
               }/style.json`;
-              const ellRef = ref.length > 10 ? ref.slice(0,7) + '...' : ref;
 
-              title.innerHTML = `<a class="link hover-dark-red" href="${url}">${github} ${
-                ref ? "(" + ellRef + ")" : ""
-              }</a>`;
+              const ellRef = (() => {
+                if (ref) return ref.length > 10 ? ref.slice(0, 7) + "..." : ref;
+                else return "";
+              })();
 
-              // Add gist parameter to style links
+              const link = document.createElement("a");
+              link.classList.add("link", "hover-dark-red");
+              link.href = url;
+              link.textContent = `${github} ${ref ? "(" + ellRef + ")" : ""}`;
+              link.rel = "noreferrer noopener";
+
+              title.innerHTML = "";
+              title.appendChild(link);
+
+              // Add github parameter to style links
               const links = document.querySelectorAll(".style-link");
               for (const link of links) {
                 const href = link.getAttribute("href");


### PR DESCRIPTION
While working on styles I can see the value of being able to pull into the comparator tool a style coming from a work uploaded into Github.

This change adds processing of `github` and `ref` parameters to load a style from a Github repository and branch. It works as follows:

* `github=org/repo`: gets your organization and repository, example `jsanz/osm-bright-gl-style`
* `ref=branch|commit`: accepts the name of an existing branch or a commit hash. If this parameter is not passed, the default branch content will be retrieved.

Example screenshot of the tool loading the style from the branch that is being discussed on this [Pull Request](https://github.com/elastic/osm-bright-gl-style/pull/4)

![image](https://user-images.githubusercontent.com/188264/88933347-90c91c00-d27f-11ea-8d61-da6c0f471954.png)
